### PR TITLE
Added support for MotionBuilder 2020

### DIFF
--- a/Source/MobuLiveLinkPlugin2020.Build.cs
+++ b/Source/MobuLiveLinkPlugin2020.Build.cs
@@ -1,0 +1,11 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+using UnrealBuildTool;
+using System.IO;
+
+public class MobuLiveLinkPlugin2020 : MobuLiveLinkPluginBase
+{
+	public MobuLiveLinkPlugin2020(ReadOnlyTargetRules Target) : base(Target, "2020")
+	{
+	}
+}

--- a/Source/MobuLiveLinkPlugin2020.Target.cs
+++ b/Source/MobuLiveLinkPlugin2020.Target.cs
@@ -1,0 +1,11 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+using UnrealBuildTool;
+using System.Collections.Generic;
+using System.IO;
+
+public class MobuLiveLinkPlugin2020Target : MobuLiveLinkPluginTargetBase
+{
+	public MobuLiveLinkPlugin2020Target(TargetInfo Target) : base(Target, "2020")
+	{}
+}


### PR DESCRIPTION
Added support for MotionBuilder 2020

The attached zip file contains MotionBuilder LiveLink plugin binaries for 2016-2020.

[MobuLiveLink.zip](https://github.com/ue4plugins/MobuLiveLink/files/4862520/MobuLiveLink.zip)
