### PR TITLE
Add 2025 support and fix a crash with saving Unreal device in an Fbx file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,2 @@
-# MotionBuilder Live Link
-
-Enables Unreal to receives data from MotionBuilder via the Live Link system.
-
-Currently built and tested with Unreal 4.27 and MotionBuilder 2016, 2017, 2018, 2019, 2020, and 2022
-
-### Pre-built plugins are available on the Releases tab here: [https://github.com/ue4plugins/MobuLiveLink/releases](https://github.com/ue4plugins/MobuLiveLink/releases)
-
-### Please see the Wiki for details on setup, usage and known issues: [https://github.com/ue4plugins/MobuLiveLink/wiki](https://github.com/ue4plugins/MobuLiveLink/wiki)
-	
-### If you have any issues or questions please log them in the issues tab
+Documentation for MotionBuilder Live Link can be found on our site:
+https://docs.unrealengine.com/en-US/Engine/Animation/LiveLinkPlugin/ConnectingLiveLinktoMobu/index.html

--- a/Source/MobuLiveLinkPlugin2025.Build.cs
+++ b/Source/MobuLiveLinkPlugin2025.Build.cs
@@ -1,0 +1,12 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+using UnrealBuildTool;
+using System.IO;
+
+public class MobuLiveLinkPlugin2025 : MobuLiveLinkPluginBase
+{
+	public MobuLiveLinkPlugin2025(ReadOnlyTargetRules Target) : base(Target, "2025")
+	{
+		CppStandard = CppStandardVersion.Cpp17;
+	}
+}

--- a/Source/MobuLiveLinkPlugin2025.Target.cs
+++ b/Source/MobuLiveLinkPlugin2025.Target.cs
@@ -1,0 +1,11 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+using UnrealBuildTool;
+using System.Collections.Generic;
+using System.IO;
+
+public class MobuLiveLinkPlugin2025Target : MobuLiveLinkPluginTargetBase
+{
+	public MobuLiveLinkPlugin2025Target(TargetInfo Target) : base(Target, "2025")
+	{}
+}

--- a/Source/Private/MobuLiveLinkDevice.cpp
+++ b/Source/Private/MobuLiveLinkDevice.cpp
@@ -150,7 +150,7 @@ bool FMobuLiveLink::DeviceOperation(kDeviceOperations pOperation)
 
 void FMobuLiveLink::SetDeviceInformation(const char* NewDeviceInformation)
 {
-	FString VersionString("v3.0.3 (");
+	FString VersionString("v3.0.4 (");
 	VersionString += __DATE__;
 	VersionString += ")";
 	HardwareVersionInfo.SetString(FStringToChar(VersionString));

--- a/Source/StreamObjects/Private/EditorActiveCameraStreamObject.cpp
+++ b/Source/StreamObjects/Private/EditorActiveCameraStreamObject.cpp
@@ -96,13 +96,21 @@ bool FEditorActiveCameraStreamObject::IsValid() const
 
 void FEditorActiveCameraStreamObject::Refresh(const TSharedPtr<ILiveLinkProvider> Provider)
 {
+	if (!bIsActive)
+	{
+		return;
+	}
+
 	FBSystem System;
 	const FBCamera* CameraModel = System.Scene->Renderer->GetCameraInPane(0);
 
-	FLiveLinkStaticDataStruct CameraData(FLiveLinkCameraStaticData::StaticStruct());
-	FModelStreamObject::UpdateSubjectTransformStaticData(CameraModel, bSendAnimatable, *CameraData.Cast<FLiveLinkCameraStaticData>());
-	FCameraStreamObject::UpdateSubjectCameraStaticData(CameraModel, *CameraData.Cast<FLiveLinkCameraStaticData>());
-	Provider->UpdateSubjectStaticData(SubjectName, ULiveLinkCameraRole::StaticClass(), MoveTemp(CameraData));
+	if (CameraModel)
+	{
+		FLiveLinkStaticDataStruct CameraData(FLiveLinkCameraStaticData::StaticStruct());
+		FModelStreamObject::UpdateSubjectTransformStaticData(CameraModel, bSendAnimatable, *CameraData.Cast<FLiveLinkCameraStaticData>());
+		FCameraStreamObject::UpdateSubjectCameraStaticData(CameraModel, *CameraData.Cast<FLiveLinkCameraStaticData>());
+		Provider->UpdateSubjectStaticData(SubjectName, ULiveLinkCameraRole::StaticClass(), MoveTemp(CameraData));
+	}
 }
 
 void FEditorActiveCameraStreamObject::UpdateSubjectFrame(const TSharedPtr<ILiveLinkProvider> Provider, FLiveLinkWorldTime WorldTime, FQualifiedFrameTime QualifiedFrameTime)


### PR DESCRIPTION
Adds MotionBuilder 2025 to the list of supported plugins. 

Addresses a crash where modifying a Device Unicast address, saving the file and then re-opening that file may cause MotionBuilder to crash.